### PR TITLE
Enabling yHaplo to be used with incomplete SNP data and investigate haplogroup delineation more easily

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ class Config(object):
     #--------------------------------------------------------------------
     isoggDate = '2016.01.04'        # date ISOGG website scraped to isoggFN
     rootHaplogroup = 'A'            # haplogroup to associate with root node
-    ancStopThresh = 2               # BFS stopping condition parameter
+    ancStopThresh = 10               # BFS stopping condition parameter
     derCollapseThresh = 2           # BFS collapsing parameter
     missingGenotype = '.'           # for text input
     missingHaplogroup = '.'         # for output
@@ -343,7 +343,7 @@ class Config(object):
 
         if self.args.writeAncDerCounts:
             self.countsAncDerFN = self.constructOutFileName(Config.countsAncDerFNtp)
-        if self.args.writeHaplogroupPaths:
+        if self.args.writeHaplogroupPaths or self.args.writeHaplogroupPathsDetail:
             self.haplogroupPathsFN = self.constructOutFileName(Config.haplogroupPathsFNtp)
         if self.args.writeDerSNPs:
             self.derSNPsFN = self.constructOutFileName(Config.derSNPsFNtp)
@@ -593,6 +593,10 @@ class Config(object):
             dest='writeHaplogroupPaths', action='store_true', default=False,
             help='end: sequence of branch labels from root to call,\n'
                  '     with counts of derived SNPs observed')
+        group.add_argument('-hpd', '--haplogroupPathsDetail', 
+            dest='writeHaplogroupPathsDetail', action='store_true', default=False,
+            help='end: sequence of branch labels from root to call,\n'
+                 '     with observed derived SNPs')
         group.add_argument('-ds', '--derSNPs', 
             dest='writeDerSNPs', action='store_true', default=False,
             help='end: lists of derived SNPs on path')

--- a/config.py
+++ b/config.py
@@ -25,8 +25,6 @@ class Config(object):
     #--------------------------------------------------------------------
     isoggDate = '2016.01.04'        # date ISOGG website scraped to isoggFN
     rootHaplogroup = 'A'            # haplogroup to associate with root node
-    ancStopThresh = 10               # BFS stopping condition parameter
-    derCollapseThresh = 2           # BFS collapsing parameter
     missingGenotype = '.'           # for text input
     missingHaplogroup = '.'         # for output
     vcfStartCol = 9                 # first data column in .vcf
@@ -543,7 +541,7 @@ class Config(object):
             dest='test1000YplatformVersion', metavar='version',
             help='1000Y testing: 23andMe sites, all samples\n'
                  '\n* the 4 test-data options above are mutually exclusive\n\n\n')
-        
+
         # test data format
         group = parser.add_mutually_exclusive_group()
         group.add_argument('-tvcf', '--test1000Yvcf', 
@@ -554,10 +552,16 @@ class Config(object):
             help='1000Y testing: use .vcf4 file rather than .genos.txt\n'
                  '\n* the 2 test-data format options above are mutually exclusive\n'
                  '  and require one of the 4 1000Y test options above.\n\n')
-    
+
         # tree traversal
         groupDescription = 'traverse tree'
         group = parser.add_argument_group('trees', groupDescription)
+        group.add_argument('--ancStopThresh', 
+            dest='ancStopThresh', default=2, 
+            help='BFS stopping condition parameter [2]')
+        group.add_argument('--derCollapseThresh', 
+            dest='derCollapseThresh', default=2, 
+            help='BFS collapsing parameter [2]')
         group.add_argument('-b', '--breadthFirst', 
             dest='traverseBF', action='store_true', default=False, 
             help='write bread-first traversal')

--- a/sample.py
+++ b/sample.py
@@ -158,7 +158,26 @@ class Sample(object):
             haplogroupPath = ''
             
         return '%s | %s' % (self.strSimple(), haplogroupPath)
-    
+
+
+    def strHaplogroupPathdetail(self):
+        'constructs a string representation with haplogroup path include SNP labels'
+        if self.mostDerivedSNP:
+            haplogroupList = {}
+            for snp in self.derSNPlist:
+                if snp.haplogroup not in haplogroupList:
+                    haplogroupList[snp.haplogroup] = [snp.labelCleaned]
+                else:
+                    haplogroupList[snp.haplogroup].append(snp.labelCleaned)
+            haplogroupPath = ["{}:{}".format(hg, ",".join(haplogroupList[hg]))
+                              for hg in sorted(haplogroupList.keys())]
+        else:
+            haplogroupPath = ""
+
+        return '%s | %s' % (self.strSimple(), " ".join(haplogroupPath))
+
+
+
     def realTimeOutput(self):
         'generate real-time output if requested'
         
@@ -490,6 +509,9 @@ class Sample(object):
         if Sample.args.writeHaplogroupPaths:
             Sample.writeHaplogroupPaths()       # uses sample.strHaplogroupPath()
         
+        if Sample.args.writeHaplogroupPathsDetail:
+            Sample.writeHaplogroupPathsDetail()       # uses sample.strHaplogroupPath()
+        
         if Sample.args.writeDerSNPs:
             Sample.writeSNPs()                  # uses sample.strSNPs(ancestral)
         
@@ -564,6 +586,18 @@ class Sample(object):
 
         Sample.errAndLog('Wrote sequences of haplogroups from root to calls,\n' + \
                          'with counts of derived SNPs observed:\n' + \
+                         '    %s\n\n' % Sample.config.haplogroupPathsFN)
+    
+    @staticmethod        
+    def writeHaplogroupPathsDetail():
+        'writes haplogroup path for each sample'
+
+        with open(Sample.config.haplogroupPathsFN, 'w') as haplogroupPathsFile: 
+            for sample in Sample.sampleList:
+                haplogroupPathsFile.write('%s\n' % sample.strHaplogroupPathdetail())
+
+        Sample.errAndLog('Wrote sequences of haplogroups from root to calls,\n' + \
+                         'with observed derived SNPs:\n' + \
                          '    %s\n\n' % Sample.config.haplogroupPathsFN)
     
     @staticmethod

--- a/tree.py
+++ b/tree.py
@@ -279,11 +279,11 @@ class Tree(object):
                 sample.appendAncDerCountTuple(path.node, numAncestral, numDerived)
             
             if path.node.isLeaf() \
-                or (numAncestral  > self.config.ancStopThresh) \
-                or (numAncestral == self.config.ancStopThresh and numDerived == 0):
+                or (numAncestral  > self.config.args.ancStopThresh) \
+                or (numAncestral == self.config.args.ancStopThresh and numDerived == 0):
                 stoppedPathList.append(path)
             else:
-                if numDerived >= self.config.derCollapseThresh:
+                if numDerived >= self.config.args.derCollapseThresh:
                     pathDeque = deque()
                 pathDeque.extend(path.fork(path.node.childList))
         


### PR DESCRIPTION
The changes provide two features for people working with incomplete Y chromosome sequencing data as it is case when using SNP arrays or target-capture approaches and the ones that are interested in exact haplogroup delineation:

1. It provides the option to specify the minimum number of ancestral alleles to be observed on a path before terminating the search further below it. Until now, it was set as a constant (ancStopThresh = 2), but they often fails the assignment when the haplogroup-specific, derived SNPs are not present in the data set for a certain branch, but the data set only contains derived SNPs for the branch below it. By being able to specify a higher threshold, samples with complete information can be assigned correctly.

2. yHaplo so far provided the option "haplogroupPaths" that reported the number of derived SNPs found on each branch of Y phylogeny until its leaf. When investigating whether a sample is part of an exisiting haplogroup sub-lineage, it is also interesting to see, which ISOGG SNPs were in fact derived. Currently, this information has to be extracted from derSNPsDetail. The new option "haplogroupPathsDetail" combines the two options by replacing the number of derived SNPs with a comma-separated list of the derived SNP names in the output of the option "haplogroupPaths".

I did not add anything to the manual or README, though, because I think that the options should be rather self-explanatory from the command-line help.